### PR TITLE
Update to Kotlin 1.5.20.

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,8 +1,8 @@
 object Versions {
     const val version = "0.9.0"
 
-    const val kotlin = "1.4.30"
-    const val serialization = "1.1.0-RC"
+    const val kotlin = "1.5.20"
+    const val serialization = "1.2.1"
 
     const val bintray = "1.8.5"
 }

--- a/yamlkt/src/commonMain/kotlin/net.mamoe.yamlkt/internal/Converters.kt
+++ b/yamlkt/src/commonMain/kotlin/net.mamoe.yamlkt/internal/Converters.kt
@@ -10,7 +10,8 @@ import kotlin.math.pow
 
 // No generic type: Long will be transformed to primitive `long` on JVM, best performance
 @Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER")
-@kotlin.internal.InlineOnly
+// TODO(#27): This breaks the compiler
+// @kotlin.internal.InlineOnly
 private inline fun CharSequence.foldFromRightOffsetIndexed(offset: Int, initial: Long, operation: (index: Int, acc: Long, Char) -> Long): Long {
     require(offset <= this.length - 1) { "length < offset" }
     var accumulator = initial
@@ -25,7 +26,8 @@ private inline fun CharSequence.foldFromRightOffsetIndexed(offset: Int, initial:
 
 // No generic type: Long will be transformed to primitive `long` on JVM, best performance
 @Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER")
-@kotlin.internal.InlineOnly
+// TODO(#27): This breaks the compiler
+// @kotlin.internal.InlineOnly
 private inline fun CharArray.foldFromRightOffsetIndexed(offset: Int, length: Int, initial: Long, operation: (index: Int, acc: Long, Char) -> Long): Long {
     var accumulator = initial
 

--- a/yamlkt/src/commonTest/kotlin/net.mamoe.yamlkt/DecoderTest.kt
+++ b/yamlkt/src/commonTest/kotlin/net.mamoe.yamlkt/DecoderTest.kt
@@ -55,30 +55,30 @@ internal class DecoderTest {
         )
     }
 
+    @Serializable
+    data class TestByteData(
+        val byte: Byte
+    )
+
     @Test
     fun testNonStrictNumberCasting() {
-        @Serializable
-        data class TestData(
-            val byte: Byte
-        )
-
         val nonStrict = Yaml {
             nonStrictNumber = true
         }
 
         assertEquals(
-            TestData(123),
+            TestByteData(123),
             nonStrict.decodeFromString(
-                TestData.serializer(), """
+                TestByteData.serializer(), """
                         byte: 123.8
                     """.trimIndent()
             )
         )
 
         assertEquals(
-            TestData(123),
+            TestByteData(123),
             nonStrict.decodeFromString(
-                TestData.serializer(), """
+                TestByteData.serializer(), """
                         byte: 123.0
                     """.trimIndent()
             )
@@ -90,7 +90,7 @@ internal class DecoderTest {
 
         assertFails {
             strict.decodeFromString(
-                TestData.serializer(), """
+                TestByteData.serializer(), """
                         byte: 123.0
                     """.trimIndent()
             )
@@ -99,49 +99,44 @@ internal class DecoderTest {
 
     @Test
     fun testNonStrictNullCasting() {
-        @Serializable
-        data class TestData(
-            val byte: Byte
-        )
-
         val yaml = Yaml {
             nonStrictNullability = true
         }
 
         assertEquals(
-            TestData(0),
+            TestByteData(0),
             yaml.decodeFromString(
-                TestData.serializer(), """
+                TestByteData.serializer(), """
                         byte: null
                     """.trimIndent()
             )
         )
 
         assertEquals(
-            TestData(123),
+            TestByteData(123),
             nonStrictNumber.decodeFromString(
-                TestData.serializer(), """
+                TestByteData.serializer(), """
                         byte: 123.0
                     """.trimIndent()
             )
         )
     }
 
+    @Serializable
+    data class TestBooleanData(
+        val bool: Boolean
+    )
+
     @Test
     fun testBooleanCasting() {
-        @Serializable
-        data class TestData(
-            val bool: Boolean
-        )
-
         fun Yaml.testBoolean(
             expect: Boolean,
             vararg string: String
         ) = string.forEach { str ->
             kotlin.runCatching {
                 assertEquals(
-                    TestData(expect),
-                    decodeFromString(TestData.serializer(), """bool: $str""")
+                    TestBooleanData(expect),
+                    decodeFromString(TestBooleanData.serializer(), """bool: $str""")
                 )
             }.exceptionOrNull()?.let { e ->
                 throw IllegalStateException("error when testing $str", e)
@@ -158,35 +153,35 @@ internal class DecoderTest {
         nonStrictNullability.testBoolean(false, "~", "null", "nUll")
     }
 
+    @Serializable
+    data class TestStringData(
+        val key: String
+    )
+
     @Test
     fun testSimpleClass() {
-        @Serializable
-        data class TestData(
-            val key: String
-        )
-
         assertEquals(
-            TestData("value"),
+            TestStringData("value"),
             Yaml.decodeFromString(
-                TestData.serializer(), """
+                TestStringData.serializer(), """
                             key: value
                         """.trimIndent()
             )
         )
     }
 
+    @Serializable
+    data class TestIntListData(
+        val list: List<Int>
+    )
+
     // primitive types and casting
     @Test
     fun testSimpleMultilineList() {
-        @Serializable
-        data class TestData(
-            val list: List<Int>
-        )
-
         assertEquals(
-            TestData(listOf(1, 2, 3)),
+            TestIntListData(listOf(1, 2, 3)),
             Yaml.decodeFromString(
-                TestData.serializer(), """
+                TestIntListData.serializer(), """
                             list:
                             - 1
                             - 2
@@ -196,9 +191,9 @@ internal class DecoderTest {
         )
 
         assertEquals(
-            TestData(listOf(1, 2, 3)),
+            TestIntListData(listOf(1, 2, 3)),
             Yaml.decodeFromString(
-                TestData.serializer(), """
+                TestIntListData.serializer(), """
                             list:
                               - 1
                               - 2
@@ -208,22 +203,22 @@ internal class DecoderTest {
         )
     }
 
+    @Serializable
+    data class TestStringMapData(
+        val map: Map<String, String>
+    )
+
     @Test
     fun testJsonMap() {
-        @Serializable
-        data class TestData(
-            val map: Map<String, String>
-        )
-
         assertEquals(
-            TestData(
+            TestStringMapData(
                 mapOf(
                     "foo" to "bar",
                     "test" to "ok"
                 )
             ),
             Yaml.decodeFromString(
-                TestData.serializer(), """
+                TestStringMapData.serializer(), """
                     map: {foo: bar, test: ok}
                 """.trimIndent()
             )
@@ -232,20 +227,15 @@ internal class DecoderTest {
 
     @Test
     fun testYamlMap() {
-        @Serializable
-        data class TestData(
-            val map: Map<String, String>
-        )
-
         assertEquals(
-            TestData(
+            TestStringMapData(
                 mapOf(
                     "foo" to "bar",
                     "test" to "ok"
                 )
             ),
             Yaml.decodeFromString(
-                TestData.serializer(), """
+                TestStringMapData.serializer(), """
                     |map: 
                     |  foo: bar
                     |  test: ok
@@ -254,44 +244,43 @@ internal class DecoderTest {
         )
     }
 
+    @Serializable
+    data class TestStringListData(
+        val list: List<String>
+    )
+
     @Test
     fun testSquareList() {
-        @Serializable
-        data class TestData(
-            val list: List<String>
-        )
-
         assertEquals(
-            TestData(listOf("foo", "bar")),
+            TestStringListData(listOf("foo", "bar")),
             Yaml.decodeFromString(
-                TestData.serializer(), """
+                TestStringListData.serializer(), """
                     list: [foo, bar]
                 """.trimIndent()
             )
         )
     }
 
+    @Serializable
+    data class TestPrimitiveTypesData(
+        val negative: Int,
+        val int: Int,
+        val short: Short,
+        val byte: Byte,
+        val long: Long,
+        val boolean: Boolean,
+        val float: Float,
+        val double: Double,
+        val char: Char,
+        val string: String,
+        val quotedString: String
+    )
+
     // primitive types and casting
     @Test
     fun testSimpleStructure() {
-
-        @Serializable
-        data class TestData(
-            val negative: Int,
-            val int: Int,
-            val short: Short,
-            val byte: Byte,
-            val long: Long,
-            val boolean: Boolean,
-            val float: Float,
-            val double: Double,
-            val char: Char,
-            val string: String,
-            val quotedString: String
-        )
-
         assertEquals(
-            TestData(
+            TestPrimitiveTypesData(
                 -1,
                 123,
                 123,
@@ -305,7 +294,7 @@ internal class DecoderTest {
                 "123"
             ),
             Yaml.decodeFromString(
-                TestData.serializer(), """
+                TestPrimitiveTypesData.serializer(), """
                     negative: -1
                     int: 123
                     short: 123

--- a/yamlkt/src/commonTest/kotlin/net.mamoe.yamlkt/YamlDynamicSerializerTest.kt
+++ b/yamlkt/src/commonTest/kotlin/net.mamoe.yamlkt/YamlDynamicSerializerTest.kt
@@ -10,13 +10,13 @@ import kotlin.test.assertEquals
  * @see YamlDynamicSerializer
  */
 internal class YamlDynamicSerializerTest {
+    @Serializable
+    data class TestData(
+        val v: @Contextual Any
+    )
+
     @Test
     fun testDynamicAsMultilineList() {
-        @Serializable
-        data class TestData(
-            val v: @Contextual Any
-        )
-
         assertEquals(
             TestData(
                 listOf("test, set, tet, tes")
@@ -35,11 +35,6 @@ internal class YamlDynamicSerializerTest {
 
     @Test
     fun testDynamicAsList() {
-        @Serializable
-        data class TestData(
-            val v: @Contextual Any
-        )
-
         assertEquals(
             TestData(
                 listOf("test, set, tet, tes")
@@ -54,11 +49,6 @@ internal class YamlDynamicSerializerTest {
 
     @Test
     fun testDynamicAsMap() {
-        @Serializable
-        data class TestData(
-            val v: @Contextual Any
-        )
-
         assertEquals(
             TestData(
                 mapOf(

--- a/yamlkt/src/jvmTest/kotlin/net/mamoe/yamlkt/decoder/BlockMapTest.kt
+++ b/yamlkt/src/jvmTest/kotlin/net/mamoe/yamlkt/decoder/BlockMapTest.kt
@@ -161,17 +161,17 @@ t:
         )
     }
 
+    @Serializable
+    data class TestData(
+        val nullable: String?,
+        val nonnull: String,
+        val nullableMap: Map<String, String>?,
+        val nullableList: List<String>?,
+    )
+
     // from https://github.com/Him188/yamlkt/issues/3
     @Test
     fun testNullValue() {
-        @Serializable
-        data class TestData(
-            val nullable: String?,
-            val nonnull: String,
-            val nullableMap: Map<String, String>?,
-            val nullableList: List<String>?,
-        )
-
         assertEquals(
             TestData(null, "value", null, null), Yaml.decodeFromString(
                 TestData.serializer(), """

--- a/yamlkt/src/jvmTest/kotlin/net/mamoe/yamlkt/decoder/BlockSequenceTest.kt
+++ b/yamlkt/src/jvmTest/kotlin/net/mamoe/yamlkt/decoder/BlockSequenceTest.kt
@@ -118,17 +118,17 @@ internal class BlockSequenceTest {
 
     }
 
+    @Serializable
+    data class NestedTestData(val item1: String, val item2: String)
+
+    @Serializable
+    data class TestData(val list: List<List<NestedTestData>>)
+
     /**
      * Test data from https://github.com/Him188/yamlkt/issues/1
      */
     @Test
     fun testNestedList() {
-        @Serializable
-        data class NestedTestData(val item1: String, val item2: String)
-
-        @Serializable
-        data class TestData(val list: List<List<NestedTestData>>)
-
         val yaml = """
             list:
             - - item1: 1
@@ -173,12 +173,6 @@ internal class BlockSequenceTest {
 
     @Test
     fun testMixedNestingList() {
-        @Serializable
-        data class NestedTestData(val item1: String, val item2: String)
-
-        @Serializable
-        data class TestData(val list: List<List<NestedTestData>>)
-
         val yaml = """
                     list:
                     - [ {item1: 1, item2: A}, { item1: 2, item2: B} ]

--- a/yamlkt/src/jvmTest/kotlin/net/mamoe/yamlkt/decoder/DeserializerTest.kt
+++ b/yamlkt/src/jvmTest/kotlin/net/mamoe/yamlkt/decoder/DeserializerTest.kt
@@ -11,36 +11,36 @@ import com.charleskorn.kaml.Yaml.Companion as Kaml
  */
 internal class DeserializerTest {
 
+    @Serializable
+    data class TestPrimitiveTypesData(
+        val negative: Int,
+        val int: Int,
+        val short: Short,
+        val byte: Byte,
+        val long: Long,
+        val boolean: Boolean,
+        val float: Float,
+        val double: Double,
+        val char: Char,
+        val string: String,
+        val quotedString: String
+    )
+
     @Test
     fun testPrimitiveTypes() {
-        @Serializable
-        data class TestData(
-            val negative: Int,
-            val int: Int,
-            val short: Short,
-            val byte: Byte,
-            val long: Long,
-            val boolean: Boolean,
-            val float: Float,
-            val double: Double,
-            val char: Char,
-            val string: String,
-            val quotedString: String
-        )
-
-        val data = TestData(1, 1, 1, 1, 1, true, 1f, 1.0, 'c', "test", "test")
-        val string = Kaml.default.encodeToString(TestData.serializer(), data)
-        assertEquals(data, Yaml.decodeFromString(TestData.serializer(), string))
+        val data = TestPrimitiveTypesData(1, 1, 1, 1, 1, true, 1f, 1.0, 'c', "test", "test")
+        val string = Kaml.default.encodeToString(TestPrimitiveTypesData.serializer(), data)
+        assertEquals(data, Yaml.decodeFromString(TestPrimitiveTypesData.serializer(), string))
     }
+
+    @Serializable
+    data class TestListsData(
+        val list: List<Int>,
+        val list2: List<String>
+    )
 
     @Test
     fun testList() {
-        @Serializable
-        data class TestData(
-            val list: List<Int>,
-            val list2: List<String>
-        )
-
         /*
 list:
 - 1
@@ -52,69 +52,69 @@ list2:
 - "test"
          */
 
-        val data = TestData(listOf(1, 1, 1, 1, 1), listOf("test"))
-        val string = Kaml.default.encodeToString(TestData.serializer(), data)
+        val data = TestListsData(listOf(1, 1, 1, 1, 1), listOf("test"))
+        val string = Kaml.default.encodeToString(TestListsData.serializer(), data)
         println(string)
-        assertEquals(data, Yaml.decodeFromString(TestData.serializer(), string))
+        assertEquals(data, Yaml.decodeFromString(TestListsData.serializer(), string))
     }
+
+    @Serializable
+    data class TestNestedListsData(
+        val negative: List<List<Int>>
+    )
 
     @Test
     fun testNestedLists() {
-        @Serializable
-        data class TestData(
-            val negative: List<List<Int>>
-        )
-
-        val data = TestData(listOf(listOf(1, 1, 1, 1, 1), listOf(2, 2, 2, 2), listOf(4, 4, 4)))
-        val string = Kaml.default.encodeToString(TestData.serializer(), data)
+        val data = TestNestedListsData(listOf(listOf(1, 1, 1, 1, 1), listOf(2, 2, 2, 2), listOf(4, 4, 4)))
+        val string = Kaml.default.encodeToString(TestNestedListsData.serializer(), data)
         println(string)
-        assertEquals(data, Yaml.decodeFromString(TestData.serializer(), string))
+        assertEquals(data, Yaml.decodeFromString(TestNestedListsData.serializer(), string))
     }
+
+    @Serializable
+    data class TestMapAndNestedListData(
+        val negative: Map<String, List<List<Int>>>
+    )
 
     @Test
     fun testNestedMapAndList() {
-        @Serializable
-        data class TestData(
-            val negative: Map<String, List<List<Int>>>
-        )
-
-        val data = TestData(
+        val data = TestMapAndNestedListData(
             mapOf(
                 "coconut" to listOf(listOf(1, 1, 1, 1, 1), listOf(1, 1, 1, 1, 1)),
                 "banana" to listOf(listOf(2, 2))
             )
         )
-        val string = Kaml.default.encodeToString(TestData.serializer(), data)
+        val string = Kaml.default.encodeToString(TestMapAndNestedListData.serializer(), data)
         println(string)
-        assertEquals(data, Yaml.decodeFromString(TestData.serializer(), string))
+        assertEquals(data, Yaml.decodeFromString(TestMapAndNestedListData.serializer(), string))
     }
+
+    @Serializable
+    data class TestMapAndListData(
+        val data: Map<String, List<String>>
+    )
 
     @Test
     fun testNestedMapAndList2() {
-        @Serializable
-        data class TestData(
-            val data: Map<String, List<String>>
-        )
-
-        val data = TestData(
+        val data = TestMapAndListData(
             mapOf(
                 "food" to listOf("banana", "apple"),
                 "book" to listOf("book1")
             )
         )
-        val string = Kaml.default.encodeToString(TestData.serializer(), data)
+        val string = Kaml.default.encodeToString(TestMapAndListData.serializer(), data)
         println(string)
-        assertEquals(data, Yaml.decodeFromString(TestData.serializer(), string))
+        assertEquals(data, Yaml.decodeFromString(TestMapAndListData.serializer(), string))
     }
+
+    @Serializable
+    data class TestNestedMapData(
+        val data: Map<String, Map<String, Int>>
+    )
 
     @Test
     fun testNestedMapMap() {
-        @Serializable
-        data class TestData(
-            val data: Map<String, Map<String, Int>>
-        )
-
-        val data = TestData(
+        val data = TestNestedMapData(
             mapOf(
                 "coconut" to mapOf(
                     "foo" to 111,
@@ -126,20 +126,20 @@ list2:
                 )
             )
         )
-        val string = Kaml.default.encodeToString(TestData.serializer(), data)
+        val string = Kaml.default.encodeToString(TestNestedMapData.serializer(), data)
         println(string)
-        assertEquals(data, Yaml.decodeFromString(TestData.serializer(), string))
+        assertEquals(data, Yaml.decodeFromString(TestNestedMapData.serializer(), string))
     }
 
     /*
+    @Serializable
+    data class TestListAsMapKeyData(
+        val data: Map<List<String>, Map<String, Int>>
+    )
+
     @Test
     fun testListAsMapKey() {
-        @Serializable
-        data class TestData(
-            val data: Map<List<String>, Map<String, Int>>
-        )
-
-        val data = TestData(
+        val data = TestListAsMapKeyData(
             mapOf(
                 listOf("coconut", "coco") to mapOf(
                     "foo" to 111,
@@ -151,8 +151,8 @@ list2:
                 )
             )
         )
-        val string = Kaml.default.stringify(TestData.serializer(), data)
+        val string = Kaml.default.stringify(TestListAsMapKeyData.serializer(), data)
         println(string)
-        assertEquals(data, Yaml.default.parse(TestData.serializer(), string))
+        assertEquals(data, Yaml.default.parse(TestListAsMapKeyData.serializer(), string))
     }*/
 }

--- a/yamlkt/src/jvmTest/kotlin/net/mamoe/yamlkt/decoder/FlowListTest.kt
+++ b/yamlkt/src/jvmTest/kotlin/net/mamoe/yamlkt/decoder/FlowListTest.kt
@@ -9,26 +9,25 @@ import kotlin.test.assertEquals
 
 
 internal class FlowListTest {
+    @Serializable
+    data class Item(
+        val id: String = "",
+        val label: String = "default"
+    )
+
+    @Serializable
+    data class TestListData(
+        val list: List<Item?>
+    )
 
     @Test
     fun `nullable list`() {
-        @Serializable
-        data class Item(
-            val id: String = "",
-            val label: String = "default"
-        )
-
-        @Serializable
-        data class TestData(
-            val list: List<Item?>
-        )
-
         assertEquals(
-            TestData(
+            TestListData(
                 listOf(Item("Open"), Item("OpenNew", "Open New"), null)
             ),
             Yaml.decodeFromString(
-                TestData.serializer(), """
+                TestListData.serializer(), """
         list: [
           {"id": "Open"},
           {"id": "OpenNew", "label": "Open New"},
@@ -39,15 +38,15 @@ internal class FlowListTest {
         )
     }
 
+    @Serializable
+    class TestNestedListData(
+        val list: List<List<String>>
+    )
+
     @Test
     fun testFlowListWithDescriptor() {
-        @Serializable
-        class TestData(
-            val list: List<List<String>>
-        )
-
         Yaml.decodeFromString(
-            TestData.serializer(), """
+            TestNestedListData.serializer(), """
     list: [[test, test, test, ]] 
     """
         )

--- a/yamlkt/src/jvmTest/kotlin/net/mamoe/yamlkt/decoder/TestMissingField.kt
+++ b/yamlkt/src/jvmTest/kotlin/net/mamoe/yamlkt/decoder/TestMissingField.kt
@@ -6,15 +6,14 @@ import org.junit.Test
 import kotlin.test.assertEquals
 
 internal class TestMissingField {
+    @Serializable
+    data class Item(
+        val id: String = "",
+        val label: String = "default"
+    )
 
     @Test
     fun `missing field in flow map`() {
-        @Serializable
-        data class Item(
-            val id: String = "",
-            val label: String = "default"
-        )
-
         assertEquals(Item("Open"), Yaml.decodeFromString(Item.serializer(), """{"id": "Open"}"""))
     }
 }

--- a/yamlkt/src/jvmTest/kotlin/net/mamoe/yamlkt/decoder/TestNewStream.kt
+++ b/yamlkt/src/jvmTest/kotlin/net/mamoe/yamlkt/decoder/TestNewStream.kt
@@ -6,13 +6,13 @@ import org.junit.Test
 
 
 internal class TestNewStream {
+    @Serializable
+    data class Data(
+        val s: String
+    )
+
     @Test
     fun testNewStream() {
-        @Serializable
-        data class Data(
-            val s: String
-        )
-
         println(
             Yaml.decodeFromString(
                 Data.serializer(), """

--- a/yamlkt/src/jvmTest/kotlin/net/mamoe/yamlkt/decoder/TestSkippingUnknownElements.kt
+++ b/yamlkt/src/jvmTest/kotlin/net/mamoe/yamlkt/decoder/TestSkippingUnknownElements.kt
@@ -6,13 +6,13 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 internal class TestSkippingUnknownElements {
+    @Serializable
+    data class Data(
+        val useful: Int
+    )
 
     @Test
     fun `skip in block map`() {
-        @Serializable
-        data class Data(
-            val useful: Int
-        )
         assertEquals(
             Data(1), Yaml.decodeFromString(
                 Data.serializer(), """
@@ -29,10 +29,6 @@ internal class TestSkippingUnknownElements {
 
     @Test
     fun `skip in flow map`() {
-        @Serializable
-        data class Data(
-            val useful: Int
-        )
         assertEquals(
             Data(1), Yaml.decodeFromString(
                 Data.serializer(), """

--- a/yamlkt/src/jvmTest/kotlin/net/mamoe/yamlkt/encoder/BlockMapTest.kt
+++ b/yamlkt/src/jvmTest/kotlin/net/mamoe/yamlkt/encoder/BlockMapTest.kt
@@ -37,19 +37,19 @@ internal class BlockMapTest {
         assertEquals(old, new)
     }
 
-    @Test
-    fun `test empty class`() {
-        @Serializable
-        class Empty {
-            override fun equals(other: Any?): Boolean {
-                return other != null && other::class == this::class
-            }
-
-            override fun hashCode(): Int {
-                return javaClass.hashCode()
-            }
+    @Serializable
+    class Empty {
+        override fun equals(other: Any?): Boolean {
+            return other != null && other::class == this::class
         }
 
+        override fun hashCode(): Int {
+            return javaClass.hashCode()
+        }
+    }
+
+    @Test
+    fun `test empty class`() {
         assertEquals("{}", allBlock.encodeToString(Empty()).trim())
     }
 }

--- a/yamlkt/src/jvmTest/kotlin/net/mamoe/yamlkt/encoder/CommentEncodeTest.kt
+++ b/yamlkt/src/jvmTest/kotlin/net/mamoe/yamlkt/encoder/CommentEncodeTest.kt
@@ -6,35 +6,26 @@ import org.junit.Test
 
 
 internal class CommentEncodeTest {
+    @Serializable
+    data class CommentTest(
+        @Comment("testA")
+        val value1: String,
+        @Comment("testA\nff")
+        val value2: String
+    )
 
     @Test
     fun testComments() {
-        @Serializable
-        data class CommentTest(
-            @Comment("testA")
-            val value1: String,
-            @Comment("testA\nff")
-            val value2: String
-        )
-
         allBlock.testDescriptorBased(CommentTest.serializer(), CommentTest("vv", "ss"), true)
     }
 
+    @Serializable
+    data class OuterClass(
+        val inner: CommentTest,
+    )
+
     @Test
     fun testCommentsWithHierarchy() {
-        @Serializable
-        data class CommentTest(
-            @Comment("testA")
-            val value1: String,
-            @Comment("testA\nff")
-            val value2: String
-        )
-
-        @Serializable
-        data class OuterClass(
-            val inner: CommentTest,
-        )
-
         allBlock.testDescriptorBased(OuterClass.serializer(), OuterClass(CommentTest("vv", "ss")), true)
     }
 }

--- a/yamlkt/src/jvmTest/kotlin/net/mamoe/yamlkt/encoder/FlowMapTest.kt
+++ b/yamlkt/src/jvmTest/kotlin/net/mamoe/yamlkt/encoder/FlowMapTest.kt
@@ -5,20 +5,19 @@ import org.junit.Test
 import kotlin.test.assertEquals
 
 class FlowMapTest {
+    @Serializable
+    class Empty {
+        override fun equals(other: Any?): Boolean {
+            return other != null && other::class == this::class
+        }
+
+        override fun hashCode(): Int {
+            return javaClass.hashCode()
+        }
+    }
 
     @Test
     fun `test empty class`() {
-        @Serializable
-        class Empty {
-            override fun equals(other: Any?): Boolean {
-                return other != null && other::class == this::class
-            }
-
-            override fun hashCode(): Int {
-                return javaClass.hashCode()
-            }
-        }
-
         assertEquals("{}", allFlow.encodeToString(Empty()).trim())
     }
 }

--- a/yamlkt/src/jvmTest/kotlin/net/mamoe/yamlkt/testsFromIssues/5.kt
+++ b/yamlkt/src/jvmTest/kotlin/net/mamoe/yamlkt/testsFromIssues/5.kt
@@ -7,13 +7,13 @@ import org.junit.Test
 import kotlin.test.assertEquals
 
 internal class Issue5 {
+    @Serializable
+    class Config(
+        var tt: String? = null,
+    )
+
     @Test
     fun test() {
-        @Serializable
-        class Config(
-            var tt: String? = null,
-        )
-
         Debugging.enabled = true
         val result = Yaml.encodeToString(Config.serializer(), Config())
         assertEquals("tt: null", result.trim(), "Result: $result")


### PR DESCRIPTION
Comment out `@InlineOnly` annotations which break the build w/ Kotlin 1.5.

Local classes can no longer be marked as `@Serializable` (see https://youtrack.jetbrains.com/issue/KT-45541) so move these out of test functions and into the test class.

See #27