### PR TITLE
Set kotlin.mpp.enableCompatibilityMetadataVariant=true

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,3 +7,6 @@ kotlin.native.ignoreDisabledTargets=true
 systemProp.org.gradle.internal.publish.checksums.insecure=true
 org.gradle.vfs.watch=true
 org.gradle.parallel=true
+
+kotlin.mpp.enableCompatibilityMetadataVariant=true
+kotlin.mpp.enableCInteropCommonization=true


### PR DESCRIPTION
The lack of those properties is causing the first error reported in https://github.com/Him188/yamlkt/issues/61.

Those are present in other KMP projects with similar versions such as https://github.com/bcmedeiros/kotlinx.html/blob/master/gradle.properties, so they seem to be safe.