### PR TITLE
Add Serialization Configuration for Char and Upgrade Kotlin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 .idea/
 .gradle/
+.kotlin/
 build/
 .idea_modules/
 hs_err_pid*
 *.hprof
 local.properties
+

--- a/benchmark/build.gradle.kts
+++ b/benchmark/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -5,36 +6,36 @@ plugins {
     kotlin("jvm")
     kotlin("kapt")
     kotlin("plugin.serialization")
-    id("me.champeau.gradle.jmh")
+    id("me.champeau.jmh")
 }
-apply(plugin = "me.champeau.gradle.jmh")
+apply(plugin = "me.champeau.jmh")
 
 dependencies {
     api(kotlin("stdlib-jdk8"))
-    api("org.openjdk.jmh:jmh-core:1.23")
-    api("org.openjdk.jmh:jmh-generator-annprocess:1.21")
+    api("org.openjdk.jmh:jmh-core:1.37")
+    api("org.openjdk.jmh:jmh-generator-annprocess:1.37")
     api(project(":yamlkt"))
     api(kotlinx("serialization-core", Versions.serialization))
     api(kotlinx("serialization-json", Versions.serialization))
-    kapt("org.openjdk.jmh:jmh-generator-annprocess:1.21")
+    kapt("org.openjdk.jmh:jmh-generator-annprocess:1.37")
     api("com.charleskorn.kaml:kaml:0.17.0")
     api("org.yaml:snakeyaml:1.26")
-    api("com.google.code.gson:gson:2.8.6")
-    api("com.alibaba:fastjson:1.2.75")
+    api("com.google.code.gson:gson:2.11.0")
+    api("com.alibaba:fastjson:1.2.83") // Next major: 2.0.51
 }
 
 
 group = ""
 
 jmh {
-    include = listOf("DeserializingTest")
+    includes.set(listOf("DeserializingTest"))
 }
 
 val compileKotlin: KotlinCompile by tasks
-compileKotlin.kotlinOptions {
-    jvmTarget = "1.8"
+compileKotlin.compilerOptions {
+    jvmTarget.set(JvmTarget.JVM_1_8)
 }
 val compileTestKotlin: KotlinCompile by tasks
-compileTestKotlin.kotlinOptions {
-    jvmTarget = "1.8"
+compileTestKotlin.compilerOptions {
+    jvmTarget.set(JvmTarget.JVM_1_8)
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     kotlin("multiplatform") version Versions.kotlin apply false
     kotlin("plugin.serialization") version Versions.kotlin apply false
 
-    id("me.champeau.gradle.jmh") version "0.5.3" apply false
+    id("me.champeau.jmh") version "0.7.2" apply false
 }
 
 allprojects {

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,8 +1,8 @@
 object Versions {
     const val version = "0.13.0"
 
-    const val kotlin = "1.8.0"
-    const val serialization = "1.5.0"
+    const val kotlin = "2.0.0"
+    const val serialization = "1.7.0"
 
     const val mavenCentralPublish = "1.0.0-dev-3"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # style guide
 kotlin.code.style=official
 kotlin.incremental.multiplatform=true
-kotlin.js.compiler=both
+kotlin.js.compiler=ir
 kotlin.native.ignoreDisabledTargets=true
 systemProp.org.gradle.internal.publish.checksums.insecure=true
 org.gradle.vfs.watch=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,10 +1,9 @@
 # style guide
 kotlin.code.style=official
 kotlin.incremental.multiplatform=true
-kotlin.js.compiler=ir
 kotlin.native.ignoreDisabledTargets=true
 systemProp.org.gradle.internal.publish.checksums.insecure=true
 org.gradle.vfs.watch=true
 
-kotlin.mpp.enableCompatibilityMetadataVariant=true
+org.gradle.jvmargs=-Xmx2g "-XX:MaxMetaspaceSize=2g"
 kotlin.mpp.enableCInteropCommonization=true

--- a/karma/config.js
+++ b/karma/config.js
@@ -1,0 +1,5 @@
+config.client = config.client || {}
+config.client.mocha = config.client.mocha || {}
+config.client.mocha.timeout = '30s'
+config.browserNoActivityTimeout = 30000
+config.browserDisconnectTimeout = 30000

--- a/yamlkt/build.gradle.kts
+++ b/yamlkt/build.gradle.kts
@@ -19,7 +19,7 @@ kotlin {
                 kotlinOptions.jvmTarget = "1.8"
             }
         }
-        js(BOTH) {
+        js(IR) {
             compilations.all {
                 kotlinOptions {
                     moduleKind = "umd"

--- a/yamlkt/build.gradle.kts
+++ b/yamlkt/build.gradle.kts
@@ -1,8 +1,3 @@
-@file:Suppress("UNUSED_VARIABLE")
-
-import org.apache.tools.ant.taskdefs.condition.Os
-import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
-
 plugins {
     id("me.him188.maven-central-publish")
     kotlin("multiplatform")
@@ -13,128 +8,46 @@ plugins {
 kotlin {
     explicitApi()
 
-    targets {
-        jvm {
-            compilations.all {
-                kotlinOptions.jvmTarget = "1.8"
-            }
-        }
-        js(IR) {
-            compilations.all {
-                kotlinOptions {
-                    moduleKind = "umd"
-                    sourceMap = true
-                    metaInfo = true
-                }
-            }
-            browser()
-            nodejs()
-        }
-
-
-        val ideaActive = System.getProperty("idea.active") == "true" && System.getProperty("publication.test") != "true"
-
-        val nativeMainSets = mutableListOf<KotlinSourceSet>()
-        val nativeTestSets = mutableListOf<KotlinSourceSet>()
-
-        if (ideaActive) {
-            when {
-                Os.isFamily(Os.FAMILY_MAC) -> if (Os.isArch("aarch64")) macosArm64("native") else macosX64("native")
-                Os.isFamily(Os.FAMILY_WINDOWS) -> mingwX64("native")
-                else -> linuxX64("native")
-            }
-        } else {
-            // https://kotlinlang.org/docs/native-target-support.html
-            // Updated for Kotlin 1.8.0, serialization 1.5.0
-            //kotlinx-serialization-core-iosarm32/                             -         -      
-            //kotlinx-serialization-core-iosarm64/                             -         -      
-            //kotlinx-serialization-core-iossimulatorarm64/                    -         -      
-            //kotlinx-serialization-core-iosx64/                               -         -      
-            //kotlinx-serialization-core-js/                                   -         -      
-            //kotlinx-serialization-core-jvm/                                  -         -      
-            //kotlinx-serialization-core-linuxarm32hfp/                        -         -      
-            //kotlinx-serialization-core-linuxarm64/                           -         -      
-            //kotlinx-serialization-core-linuxx64/                             -         -      
-            //kotlinx-serialization-core-macosarm64/                           -         -      
-            //kotlinx-serialization-core-macosx64/                             -         -      
-            //kotlinx-serialization-core-metadata/                             -         -      
-            //kotlinx-serialization-core-mingwx64/                             -         -      
-            //kotlinx-serialization-core-mingwx86/                             -         -      
-            //kotlinx-serialization-core-tvosarm64/                            -         -      
-            //kotlinx-serialization-core-tvossimulatorarm64/                   -         -      
-            //kotlinx-serialization-core-tvosx64/                              -         -      
-            //kotlinx-serialization-core-watchosarm32/                         -         -      
-            //kotlinx-serialization-core-watchosarm64/                         -         -      
-            //kotlinx-serialization-core-watchossimulatora.../                 -         -      
-            //kotlinx-serialization-core-watchosx64/                           -         -      
-            //kotlinx-serialization-core-watchosx86/            
-            // Commented ones are not supported by kotlinx-coroutines-core
-            val nativeTargets: List<String> = arrayOf(
-                // Tier 1:
-                "linuxX64",
-                "macosX64",
-                "macosArm64",
-                "iosSimulatorArm64",
-                "iosX64",
-
-                // Tier 2:
-                "linuxArm64",
-//                "watchosSimulatorArm64",
-                "watchosX64w",
-                "wwatchosArm32",
-                "watchosArm64",
-                "tvosSimulatorArm64",
-                "tvosX64",
-                "tvosArm64",
-                "iosArm64",
-
-                // Tier 3:
-//                "androidNativeArm32",
-//                "androidNativeArm64",
-//                "androidNativeX86",
-//                "androidNativeX64",
-                "mingwX64",
-//                "watchosDeviceArm64",
-
-                // Deprecated:
-                "iosArm32",
-                "watchosX86",
-//                "wasm32",
-                "mingwX86",
-                "linuxArm32Hfp",
-//                "linuxMips32",
-//                "linuxMipsel32",
-            ).flatMap { it.split(", ") }
-            presets.filter { it.name in nativeTargets }
-                .forEach { preset ->
-                    val target = targetFromPreset(preset, preset.name)
-                    nativeMainSets.add(target.compilations[org.jetbrains.kotlin.gradle.plugin.KotlinCompilation.MAIN_COMPILATION_NAME].kotlinSourceSets.first())
-                    nativeTestSets.add(target.compilations[org.jetbrains.kotlin.gradle.plugin.KotlinCompilation.TEST_COMPILATION_NAME].kotlinSourceSets.first())
-                }
-
-            sourceSets {
-                if (!ideaActive) {
-                    configure(nativeMainSets) {
-                        dependsOn(sourceSets.maybeCreate("nativeMain"))
-                    }
-
-                    configure(nativeTestSets) {
-                        dependsOn(sourceSets.maybeCreate("nativeTest"))
-                    }
+    jvmToolchain(8)
+    jvm()
+    js {
+        browser {
+            testTask {
+                useKarma {
+                    useChromeHeadless()
+                    useConfigDirectory(rootDir.resolve("karma"))
                 }
             }
         }
-
-        /*
-        val hostOs = System.getProperty("os.name")
-        val isMingwX64 = hostOs.startsWith("Windows")
-        val nativeTarget = when {
-            hostOs == "Mac OS X" -> macosX64("native")
-            hostOs == "Linux" -> linuxX64("native")
-            isMingwX64 -> mingwX64("native")
-            else -> throw GradleException("Host OS is not supported in Kotlin/Native.")
-        }*/
     }
+
+    // https://kotlinlang.org/docs/native-target-support.html
+    // Updated for Kotlin 2.0.0, serialization 1.7.0
+    // Commented ones are not supported by kotlinx-coroutines-core
+
+    // Tier 1:
+    macosX64()
+    macosArm64()
+    iosSimulatorArm64()
+    iosX64()
+
+    // Tier 2:
+    linuxX64()
+    linuxArm64()
+    watchosSimulatorArm64()
+    watchosX64()
+    watchosArm32()
+    watchosArm64()
+    tvosSimulatorArm64()
+    tvosX64()
+    tvosArm64()
+    iosArm64()
+
+    // Tier 3:
+    androidNativeArm32()
+    androidNativeArm64()
+    androidNativeX86()
+    androidNativeX64()
 
     sourceSets {
         val serializationVersion: String = Versions.serialization
@@ -166,25 +79,12 @@ kotlin {
                 api(kotlin("reflect"))
             }
         }
-
-        val jvmMain by getting
         val jvmTest by getting {
             dependencies {
                 api(kotlin("test-junit"))
                 api("com.charleskorn.kaml:kaml:0.34.0")
                 api("org.yaml:snakeyaml:1.26")
             }
-        }
-
-        val jsMain by getting
-        val jsTest by getting
-
-        val nativeMain by getting {
-            dependsOn(commonMain)
-        }
-
-        val nativeTest by getting {
-            dependsOn(commonTest)
         }
     }
 }

--- a/yamlkt/src/commonMain/kotlin/net.mamoe.yamlkt/YamlConfigurationInternal.kt
+++ b/yamlkt/src/commonMain/kotlin/net.mamoe.yamlkt/YamlConfigurationInternal.kt
@@ -97,14 +97,14 @@ public class YamlBuilder internal constructor(
         /**
          * Quote all [Char]s with `'`
          *
-         * If a value can't be serialized using single quotation, it will use [CHAR_DOUBLE_QUOTATION]
+         * If a value can't be serialized using single quotation, it will use [DOUBLE_QUOTATION]
          */
-        CHAR_SINGLE_QUOTATION,
+        SINGLE_QUOTATION,
 
         /**
          * Quote all [Char]s with `"`
          */
-        CHAR_DOUBLE_QUOTATION,
+        DOUBLE_QUOTATION,
 
         /**
          * Encode [Char]s as their [code][Char.code] in integer.
@@ -112,14 +112,14 @@ public class YamlBuilder internal constructor(
          *
          * For example, the character 'A' will be converted to 65
          */
-        CHAR_UNICODE_CODE,
+        UNICODE_CODE,
 
         /**
          * Don't quote any [Char].
          *
-         * When escaping is necessary, it defaults to using [CHAR_SINGLE_QUOTATION]
+         * When escaping is necessary, it defaults to using [SINGLE_QUOTATION]
          */
-        NORMAL,
+        PLAIN,
     }
 
 
@@ -272,7 +272,7 @@ internal class YamlConfigurationInternal internal constructor(
     // encoding
     @JvmField val encodeDefaultValues: Boolean = true,
     @JvmField val stringSerialization: YamlBuilder.StringSerialization = YamlBuilder.StringSerialization.NONE,
-    @JvmField val charSerialization: YamlBuilder.CharSerialization = YamlBuilder.CharSerialization.NORMAL,
+    @JvmField val charSerialization: YamlBuilder.CharSerialization = YamlBuilder.CharSerialization.PLAIN,
     @JvmField val nullSerialization: YamlBuilder.NullSerialization = YamlBuilder.NullSerialization.NULL,
     @JvmField val mapSerialization: MapSerialization = MapSerialization.BLOCK_MAP,
     @JvmField val classSerialization: MapSerialization = MapSerialization.BLOCK_MAP,

--- a/yamlkt/src/commonMain/kotlin/net.mamoe.yamlkt/YamlConfigurationInternal.kt
+++ b/yamlkt/src/commonMain/kotlin/net.mamoe.yamlkt/YamlConfigurationInternal.kt
@@ -107,16 +107,15 @@ public class YamlBuilder internal constructor(
         CHAR_DOUBLE_QUOTATION,
 
         /**
-         * Convert all [Char]s to their corresponding Unicode code points [Int]
+         * Encode [Char]s as their [code][Char.code] in integer.
+         * _(It will work like [Byte])_
          *
          * For example, the character 'A' will be converted to 65
-         *
-         * It will work like [Byte]
          */
         CHAR_UNICODE_CODE,
 
         /**
-         * Directly use the character content of [Char]
+         * Don't quote any [Char].
          *
          * When escaping is necessary, it defaults to using [CHAR_SINGLE_QUOTATION]
          */

--- a/yamlkt/src/commonMain/kotlin/net.mamoe.yamlkt/YamlConfigurationInternal.kt
+++ b/yamlkt/src/commonMain/kotlin/net.mamoe.yamlkt/YamlConfigurationInternal.kt
@@ -54,6 +54,12 @@ public class YamlBuilder internal constructor(
     public var stringSerialization: StringSerialization = conf.stringSerialization
 
     /**
+     * Configure how to serialize chars
+     * */
+    @JvmField
+    public var charSerialization: CharSerialization = conf.charSerialization
+
+    /**
      * The value set for `null` serialization.
      * Default: serialize `null` as "null"
      */
@@ -79,6 +85,43 @@ public class YamlBuilder internal constructor(
      */
     @JvmField
     public var listSerialization: ListSerialization = conf.listSerialization
+
+    /**
+     * The suggested format for [Char] serialization.
+     *
+     * [Char] isn't always serialized in this format, depending on the content.
+     *
+     * Some escape sequences of special characters will be processed as escaped characters _(such as '\n')_
+     * */
+    public enum class CharSerialization {
+        /**
+         * Quote all [Char]s with `'`
+         *
+         * If a value can't be serialized using single quotation, it will use [CHAR_DOUBLE_QUOTATION]
+         */
+        CHAR_SINGLE_QUOTATION,
+
+        /**
+         * Quote all [Char]s with `"`
+         */
+        CHAR_DOUBLE_QUOTATION,
+
+        /**
+         * Convert all [Char]s to their corresponding Unicode code points [Int]
+         *
+         * For example, the character 'A' will be converted to 65
+         *
+         * It will work like [Byte]
+         */
+        CHAR_UNICODE_CODE,
+
+        /**
+         * Directly use the character content of [Char]
+         *
+         * When escaping is necessary, it defaults to using [CHAR_SINGLE_QUOTATION]
+         */
+        NORMAL,
+    }
 
 
     /**
@@ -213,6 +256,7 @@ public class YamlBuilder internal constructor(
         nonStrictNumber,
         encodeDefaultValues,
         stringSerialization,
+        charSerialization,
         nullSerialization,
         mapSerialization,
         classSerialization,
@@ -229,6 +273,7 @@ internal class YamlConfigurationInternal internal constructor(
     // encoding
     @JvmField val encodeDefaultValues: Boolean = true,
     @JvmField val stringSerialization: YamlBuilder.StringSerialization = YamlBuilder.StringSerialization.NONE,
+    @JvmField val charSerialization: YamlBuilder.CharSerialization = YamlBuilder.CharSerialization.NORMAL,
     @JvmField val nullSerialization: YamlBuilder.NullSerialization = YamlBuilder.NullSerialization.NULL,
     @JvmField val mapSerialization: MapSerialization = MapSerialization.BLOCK_MAP,
     @JvmField val classSerialization: MapSerialization = MapSerialization.BLOCK_MAP,

--- a/yamlkt/src/commonMain/kotlin/net.mamoe.yamlkt/internal/Converters.kt
+++ b/yamlkt/src/commonMain/kotlin/net.mamoe.yamlkt/internal/Converters.kt
@@ -100,6 +100,10 @@ internal object BinaryConverter {
     }
 }
 
+internal fun Long.limitToChar(): Char {
+    if (this in Char.MIN_VALUE.code.toLong()..Char.MAX_VALUE.code.toLong()) return toInt().toChar()
+    error("value is too large for byte: $this")
+}
 
 internal fun Long.limitToByte(): Byte {
     if (this in Byte.MIN_VALUE.toLong()..Byte.MAX_VALUE.toLong()) return this.toByte()

--- a/yamlkt/src/commonMain/kotlin/net.mamoe.yamlkt/internal/Escape.kt
+++ b/yamlkt/src/commonMain/kotlin/net.mamoe.yamlkt/internal/Escape.kt
@@ -9,7 +9,6 @@ import net.mamoe.yamlkt.YamlBuilder.StringSerialization.*
 import kotlin.jvm.JvmMultifileClass
 import kotlin.jvm.JvmName
 import kotlin.jvm.JvmStatic
-import kotlin.native.concurrent.SharedImmutable
 
 
 // region EscapeCharMappings
@@ -25,7 +24,6 @@ internal const val STRING_ESC = '\\'
 internal const val INVALID = 0.toChar()
 internal const val UNICODE_ESC = 'u'
 
-@SharedImmutable
 internal val REPLACEMENT_CHARS: Array<String?> = arrayOfNulls<String?>(128).apply {
     for (i in 0..0xf) {
         this[i] = "\\u000$i"

--- a/yamlkt/src/commonMain/kotlin/net.mamoe.yamlkt/internal/Escape.kt
+++ b/yamlkt/src/commonMain/kotlin/net.mamoe.yamlkt/internal/Escape.kt
@@ -688,7 +688,7 @@ internal fun String.getQuotationAvailability(): Int {
             c == ':' -> lastIsColon = true
             c == ' ' && lastIsColon -> canBeUnquoted = false
             c in """
-                []{}"'$^*|>-?/~
+                []{}"'$^*|>-?/~,
                 """.trimIndent() -> { // less mistakes
                 canBeUnquoted = false
             }

--- a/yamlkt/src/commonMain/kotlin/net.mamoe.yamlkt/internal/Escape.kt
+++ b/yamlkt/src/commonMain/kotlin/net.mamoe.yamlkt/internal/Escape.kt
@@ -4,7 +4,7 @@
 package net.mamoe.yamlkt.internal
 
 import net.mamoe.yamlkt.YamlBuilder
-import net.mamoe.yamlkt.YamlBuilder.CharSerialization.*
+import net.mamoe.yamlkt.YamlBuilder.CharSerialization
 import net.mamoe.yamlkt.YamlBuilder.StringSerialization.*
 import kotlin.jvm.JvmMultifileClass
 import kotlin.jvm.JvmName
@@ -604,13 +604,13 @@ internal fun Char.isHexDigit(): Boolean = this in '0'..'9' || this in 'a'..'f' |
 private const val ESCAPED_CHARACTERS: String = "[]{}\"'\\$^*|>-?/~,:#"
 
 internal fun Char.encodeEscapedString(
-    charSerialization: YamlBuilder.CharSerialization
+    charSerialization: CharSerialization
 ): String {
-    if (charSerialization == CHAR_UNICODE_CODE) {
+    if (charSerialization == CharSerialization.UNICODE_CODE) {
         return this.code.toString()
     }
-    var requiresDoubleQuoted = charSerialization == CHAR_DOUBLE_QUOTATION || this == '\''
-    val requiresSingleQuoted = charSerialization == CHAR_SINGLE_QUOTATION || this in ESCAPED_CHARACTERS || this == ' '
+    var requiresDoubleQuoted = charSerialization == CharSerialization.DOUBLE_QUOTATION || this == '\''
+    val requiresSingleQuoted = charSerialization == CharSerialization.SINGLE_QUOTATION || this in ESCAPED_CHARACTERS || this == ' '
 
     val escapedChars = REPLACEMENT_CHARS.getOrNull(this.code)?.also { requiresDoubleQuoted = true } ?: this.toString()
 

--- a/yamlkt/src/commonMain/kotlin/net.mamoe.yamlkt/internal/YamlDecoder.kt
+++ b/yamlkt/src/commonMain/kotlin/net.mamoe.yamlkt/internal/YamlDecoder.kt
@@ -1014,8 +1014,11 @@ internal class YamlDecoder(
 
     private fun String?.decodeCharElementImpl(descriptor: SerialDescriptor?, index: Int): Char =
         this.debuggingLogDecoder(descriptor, index)?.let {
-            check(it.length == 1) { "too many chars for a char: $it" }
-            it.first()
+            when {
+                it.length == 1 -> it.first()
+                it.any { !it.isDigit() } -> error("too many chars for a char: $it")
+                else -> withIntegerValue("char", descriptor, index).limitToChar()
+            }
         } ?: checkNonStrictNullability(descriptor, index)
         ?: 0.toChar()
 

--- a/yamlkt/src/commonMain/kotlin/net.mamoe.yamlkt/internal/YamlDecoder.kt
+++ b/yamlkt/src/commonMain/kotlin/net.mamoe.yamlkt/internal/YamlDecoder.kt
@@ -1016,7 +1016,7 @@ internal class YamlDecoder(
         this.debuggingLogDecoder(descriptor, index)?.let {
             when {
                 it.length == 1 -> it.first()
-                it.any { !it.isDigit() } -> error("too many chars for a char: $it")
+                it.any { !it.isDigit() } -> throw contextualDecodingException("too many chars for a char: $it")
                 else -> withIntegerValue("char", descriptor, index).limitToChar()
             }
         } ?: checkNonStrictNullability(descriptor, index)

--- a/yamlkt/src/commonMain/kotlin/net.mamoe.yamlkt/internal/YamlEncoder.kt
+++ b/yamlkt/src/commonMain/kotlin/net.mamoe.yamlkt/internal/YamlEncoder.kt
@@ -460,7 +460,7 @@ internal class YamlEncoder(
 
     override fun encodeBoolean(value: Boolean) = writer.write(if (value) "true" else "false")
     override fun encodeByte(value: Byte) = writer.write(value.toInt().toString())
-    override fun encodeChar(value: Char) = writer.write(value)
+    override fun encodeChar(value: Char) = writer.write(value.encodeEscapedString(configuration.charSerialization))
     override fun encodeDouble(value: Double) = writer.write(value.toString())
     override fun encodeEnum(enumDescriptor: SerialDescriptor, index: Int) =
         writer.write(enumDescriptor.getElementName(index))
@@ -652,7 +652,7 @@ internal class YamlEncoder(
             encodeValue(if (value) "true" else "false")
 
         final override fun encodeByte(value: Byte) = encodeValue(value.toString())
-        final override fun encodeChar(value: Char) = encodeValue(value)
+        final override fun encodeChar(value: Char) = encodeValue(value.encodeEscapedString(configuration.charSerialization))
         final override fun encodeDouble(value: Double) = encodeValue(value.toString())
         final override fun encodeEnum(enumDescriptor: SerialDescriptor, index: Int) =
             encodeValue(enumDescriptor.getElementName(index))

--- a/yamlkt/src/commonTest/kotlin/net.mamoe.yamlkt/decoder/FlowListTest.kt
+++ b/yamlkt/src/commonTest/kotlin/net.mamoe.yamlkt/decoder/FlowListTest.kt
@@ -133,4 +133,11 @@ internal class FlowListTest {
             )
         )
     }
+
+    @Test
+    fun testContainingCommasFlow() {
+        // https://github.com/Him188/yamlkt/issues/68
+        assertEquals("[ foo, 'bar, baz' ]", allFlow.encodeToString(listOf("foo", "bar, baz")))
+        assertEquals(listOf("foo", "bar, baz"), allFlow.decodeFromString("[ foo, 'bar, baz' ]"))
+    }
 }

--- a/yamlkt/src/commonTest/kotlin/net.mamoe.yamlkt/encoder/BasicEncoderTest.kt
+++ b/yamlkt/src/commonTest/kotlin/net.mamoe.yamlkt/encoder/BasicEncoderTest.kt
@@ -1,8 +1,11 @@
 package net.mamoe.yamlkt.encoder
 
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
 import net.mamoe.yamlkt.Yaml.Default
 import kotlin.test.Test
+import kotlin.test.assertEquals
 
 
 internal class BasicEncoderTest {
@@ -67,6 +70,18 @@ internal class BasicEncoderTest {
             Data("value1", 123456, anotherData = Data(number = 111), byteArray = "test byteArray".encodeToByteArray())
         )
     }
+
+    @Test
+    fun testSpecialChar() {
+        val origin = listOf(':','#','\n','\r','a','c')
+        assertEquals(
+            origin,
+            allFlow.decodeFromString<List<Char>>(
+                allFlow.encodeToString<List<Char>>(origin)
+            )
+        )
+    }
+
 
     /*
     Data(v1=value1, number=123456, map={bob=2}, list=[value1, value2], anotherData=Data(v1=, number=111, map={bob=2}, list=[value1, value2], anotherData=null))

--- a/yamlkt/src/commonTest/kotlin/net.mamoe.yamlkt/encoder/TestEncoderEscape.kt
+++ b/yamlkt/src/commonTest/kotlin/net.mamoe.yamlkt/encoder/TestEncoderEscape.kt
@@ -1,6 +1,5 @@
 package net.mamoe.yamlkt.encoder
 
-import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import net.mamoe.yamlkt.Yaml
 import net.mamoe.yamlkt.YamlBuilder
@@ -20,18 +19,7 @@ private val best = Yaml {
     stringSerialization = YamlBuilder.StringSerialization.BEST_PERFORMANCE
 }
 
-private val PLAIN = Yaml {
-    charSerialization = YamlBuilder.CharSerialization.PLAIN
-}
-private val singleChar = Yaml {
-    charSerialization = YamlBuilder.CharSerialization.SINGLE_QUOTATION
-}
-private val doubleChar = Yaml {
-    charSerialization = YamlBuilder.CharSerialization.DOUBLE_QUOTATION
-}
-private val unicode = Yaml {
-    charSerialization = YamlBuilder.CharSerialization.UNICODE_CODE
-}
+
 
 internal class TestEncoderEscape {
     @Test
@@ -66,16 +54,6 @@ internal class TestEncoderEscape {
         assertEquals("\' \'", single.encodeToString<String>(" "))
         assertEquals("\' \'", none.encodeToString<String>(" "))
         assertEquals("\' \'", best.encodeToString<String>(" "))
-    }
-
-    @Test
-    fun testCharEscape() {
-        assertEquals("\" \"", doubleChar.encodeToString<Char>(' '))
-        assertEquals("\' \'", singleChar.encodeToString<Char>(' '))
-        assertEquals("\' \'", PLAIN.encodeToString<Char>(' '))
-        assertEquals("32", unicode.encodeToString<Char>(' '))
-
-        assertEquals(' ', unicode.decodeFromString<Char>("32"))
     }
 
     @Test

--- a/yamlkt/src/commonTest/kotlin/net.mamoe.yamlkt/encoder/TestEncoderEscape.kt
+++ b/yamlkt/src/commonTest/kotlin/net.mamoe.yamlkt/encoder/TestEncoderEscape.kt
@@ -1,5 +1,6 @@
 package net.mamoe.yamlkt.encoder
 
+import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import net.mamoe.yamlkt.Yaml
 import net.mamoe.yamlkt.YamlBuilder
@@ -19,6 +20,18 @@ private val best = Yaml {
     stringSerialization = YamlBuilder.StringSerialization.BEST_PERFORMANCE
 }
 
+private val normal = Yaml {
+    charSerialization = YamlBuilder.CharSerialization.NORMAL
+}
+private val singleChar = Yaml {
+    charSerialization = YamlBuilder.CharSerialization.CHAR_SINGLE_QUOTATION
+}
+private val doubleChar = Yaml {
+    charSerialization = YamlBuilder.CharSerialization.CHAR_DOUBLE_QUOTATION
+}
+private val unicode = Yaml {
+    charSerialization = YamlBuilder.CharSerialization.CHAR_UNICODE_CODE
+}
 
 internal class TestEncoderEscape {
     @Test
@@ -53,6 +66,16 @@ internal class TestEncoderEscape {
         assertEquals("\' \'", single.encodeToString<String>(" "))
         assertEquals("\' \'", none.encodeToString<String>(" "))
         assertEquals("\' \'", best.encodeToString<String>(" "))
+    }
+
+    @Test
+    fun testCharEscape() {
+        assertEquals("\" \"", doubleChar.encodeToString<Char>(' '))
+        assertEquals("\' \'", singleChar.encodeToString<Char>(' '))
+        assertEquals("\' \'", normal.encodeToString<Char>(' '))
+        assertEquals("32", unicode.encodeToString<Char>(' '))
+
+        assertEquals(' ', unicode.decodeFromString<Char>("32"))
     }
 
     @Test

--- a/yamlkt/src/commonTest/kotlin/net.mamoe.yamlkt/encoder/TestEncoderEscape.kt
+++ b/yamlkt/src/commonTest/kotlin/net.mamoe.yamlkt/encoder/TestEncoderEscape.kt
@@ -20,17 +20,17 @@ private val best = Yaml {
     stringSerialization = YamlBuilder.StringSerialization.BEST_PERFORMANCE
 }
 
-private val normal = Yaml {
-    charSerialization = YamlBuilder.CharSerialization.NORMAL
+private val PLAIN = Yaml {
+    charSerialization = YamlBuilder.CharSerialization.PLAIN
 }
 private val singleChar = Yaml {
-    charSerialization = YamlBuilder.CharSerialization.CHAR_SINGLE_QUOTATION
+    charSerialization = YamlBuilder.CharSerialization.SINGLE_QUOTATION
 }
 private val doubleChar = Yaml {
-    charSerialization = YamlBuilder.CharSerialization.CHAR_DOUBLE_QUOTATION
+    charSerialization = YamlBuilder.CharSerialization.DOUBLE_QUOTATION
 }
 private val unicode = Yaml {
-    charSerialization = YamlBuilder.CharSerialization.CHAR_UNICODE_CODE
+    charSerialization = YamlBuilder.CharSerialization.UNICODE_CODE
 }
 
 internal class TestEncoderEscape {
@@ -72,7 +72,7 @@ internal class TestEncoderEscape {
     fun testCharEscape() {
         assertEquals("\" \"", doubleChar.encodeToString<Char>(' '))
         assertEquals("\' \'", singleChar.encodeToString<Char>(' '))
-        assertEquals("\' \'", normal.encodeToString<Char>(' '))
+        assertEquals("\' \'", PLAIN.encodeToString<Char>(' '))
         assertEquals("32", unicode.encodeToString<Char>(' '))
 
         assertEquals(' ', unicode.decodeFromString<Char>("32"))

--- a/yamlkt/src/commonTest/kotlin/net.mamoe.yamlkt/escaping/CharEscapingTest.kt
+++ b/yamlkt/src/commonTest/kotlin/net.mamoe.yamlkt/escaping/CharEscapingTest.kt
@@ -1,0 +1,73 @@
+package net.mamoe.yamlkt.escaping
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import net.mamoe.yamlkt.Yaml
+import net.mamoe.yamlkt.YamlBuilder
+import net.mamoe.yamlkt.encoder.allFlow
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+private val plain = Yaml {
+    charSerialization = YamlBuilder.CharSerialization.PLAIN
+}
+private val singleChar = Yaml {
+    charSerialization = YamlBuilder.CharSerialization.SINGLE_QUOTATION
+}
+private val doubleChar = Yaml {
+    charSerialization = YamlBuilder.CharSerialization.DOUBLE_QUOTATION
+}
+private val unicode = Yaml {
+    charSerialization = YamlBuilder.CharSerialization.UNICODE_CODE
+}
+
+internal class CharEscapingTest {
+
+    @Serializable
+    data class Container(
+        val c: Char,
+    )
+
+    @Test
+    fun testTopElement() {
+        assertEquals("\" \"", doubleChar.encodeToString<Char>(' '))
+        assertEquals("\' \'", singleChar.encodeToString<Char>(' '))
+        assertEquals("\' \'", plain.encodeToString<Char>(' '))
+        assertEquals("32", unicode.encodeToString<Char>(' '))
+
+        assertEquals(' ', unicode.decodeFromString<Char>("32"))
+    }
+
+    @Test
+    fun testClass() {
+        assertEquals("c: \" \"",doubleChar.encodeToString<Container>(Container(' ')))
+        assertEquals("c: ' '",singleChar.encodeToString<Container>(Container(' ')))
+        assertEquals("c: ' '",plain.encodeToString<Container>(Container(' ')))
+        assertEquals("c: 32",unicode.encodeToString<Container>(Container(' ')))
+
+        assertEquals(Container(' '),doubleChar.decodeFromString<Container>("c: \" \""))
+        assertEquals(Container(' '),singleChar.decodeFromString<Container>("c: ' '"))
+        assertEquals(Container(' '),plain.decodeFromString<Container>("c: ' '"))
+        assertEquals(Container(' '),unicode.decodeFromString<Container>("c: 32"))
+    }
+
+    @Test
+    fun testList() {
+        val list = charArrayOf(' ','\n',',','-','a','文',':')
+        assertEquals("[ ' ', \"\\n\", ',', '-', a, 文, ':' ]",allFlow.encodeToString(list))
+        assertEquals(list.concatToString(), allFlow.decodeFromString<CharArray>("[ ' ', \"\\n\", ',', '-', a, 文, ':' ]").concatToString())
+    }
+
+    @Test
+    fun testMap() {
+        val map = mapOf(
+            'a' to 'b'
+        )
+        assertEquals(map, allFlow.decodeFromString(allFlow.encodeToString(map)))
+        assertEquals(map, unicode.decodeFromString(unicode.encodeToString(map)))
+        assertEquals(map, allFlow.decodeFromString("{ a: 98 }"))
+    }
+
+
+}


### PR DESCRIPTION
fix #53 , #68 

### ✨ Add Serialization Configuration for Char
When creating a Yaml object, you can specify the handling logic for char:

```kotlin
 public enum class CharSerialization {
        SINGLE_QUOTATION,
        DOUBLE_QUOTATION,
        UNICODE_CODE,
        PLAIN,
}
```
> By default, this setting (`charSerialization` in `YamlConfigurationInternal`) is set to `PLAIN`.

Among these, `UNICODE_CODE` supports the serialization and deserialization of `Unicode`. You can now handle `Char` with logic similar to `Byte`.

Additionally, escaping support for char serialization has been added to prevent certain characters _(like `'\n'`, `'"'`, etc.)_ from being incorrectly input into the content. They will now be escaped with quotes. 

> The handling logic here is similar to String.

### ⬆️ Upgrade kotlin
Upgraded the project's kotlin version to `2.0.0`. For compatibility, also updated `kotlinx.serialization` to `1.7.0`.

I encountered the same compilation issue as in #72 while attempting the update and fixed it by referring to the corresponding comment.

Therefore, theoretically, this PR should also support the content in #72 and it seems it should fix #67 as well.
